### PR TITLE
Fix inherited class color in (eg.) TypeScript

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to the extension will be documented in this file.
 
+## [0.0.4]
+
+- Normalize inherited class colors [#8](https://github.com/mausworks/mausworks-theme-vscode/pull/8)
+
+
 ## [0.0.3]
 
 - Make comment color (and things of the same shade) a bit lighter

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "displayName": "Mausworks Theme",
   "description": "A dark, colorful and tasty theme for VSCode",
   "publisher": "mausworks",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "icon": "logo.png",
   "author": {
     "name": "Rasmus Wennerström",

--- a/themes/Mausworks Night-color-theme.json
+++ b/themes/Mausworks Night-color-theme.json
@@ -527,12 +527,11 @@
       }
     },
     {
-      "name": "String, Symbols, Inherited Class, Markup Heading",
+      "name": "String, Symbols, Markup Heading",
       "scope": [
         "string",
         "constant.other.symbol",
         "constant.other.key",
-        "entity.other.inherited-class",
         "markup.heading",
         "markup.inserted.git_gutter",
         "meta.group.braces.curly constant.other.object.key.js string.unquoted.label.js"
@@ -548,6 +547,7 @@
         "support.type",
         "support.class",
         "meta.use.php",
+        "entity.other.inherited-class",
         "support.other.namespace.use.php",
         "support.other.namespace.php",
         "markup.changed.git_gutter",


### PR DESCRIPTION
Inherited classes and interfaces now have the same color as other classes and interfaces.

![image](https://user-images.githubusercontent.com/8259221/115784820-ea014e80-a3be-11eb-8019-444355840ac4.png)
