### PR TITLE
Haskell improvements and some revamping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 All notable changes to the extension will be documented in this file.
 
+## [0.1.0]
+
+First field-tested minor release:
+
+- All languages: Self, this, super and base are now cyan and italic
+- Haskell: Most operators are now cyan (unlike other languages)
+- Haskell: Type definitions are green (like other languages)
+- Haskell: Parens and brackets are white (like other languages)
+- Rust (and other languages): Namespaces are now green
+- Rust: The mutable operator (mut) is now gray (but still italic)
+- JavaScript & TypeScript: The `in` and `of` keywords are now gray
+
 ## [0.0.5]
 
 - Touch up colorization HTML-like languages

--- a/README.md
+++ b/README.md
@@ -6,9 +6,9 @@ A dark, colorful and tasty theme for VSCode.
 - Editor font: Cascadia Code
 - UI Font: Archivo
 
-Syntax highlighting tested for:
+Syntax highlighting field-tested for:
 
- - TypeScript and JavaScript
+ - TypeScript & JavaScript
  - Python
  - C#
  - JSON
@@ -18,3 +18,4 @@ Syntax highlighting tested for:
  - Rust
  - Markdown
  - shell script
+ - Haskell ([#10](https://github.com/mausworks/mausworks-theme-vscode/issues/10))

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-A dark, colorful and tasty theme for VSCode.
+A dark, colorful and spicy theme for VSCode.
 
 ![Screenshot](./screenshot.png)
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "mausworks-theme-vscode",
   "displayName": "Mausworks Theme",
-  "description": "A dark, colorful and tasty theme for VSCode",
+  "description": "A dark, colorful and spicy theme for VSCode",
   "publisher": "mausworks",
   "version": "0.1.0",
   "icon": "logo.png",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "displayName": "Mausworks Theme",
   "description": "A dark, colorful and tasty theme for VSCode",
   "publisher": "mausworks",
-  "version": "0.0.5",
+  "version": "0.1.0",
   "icon": "logo.png",
   "author": {
     "name": "Rasmus Wennerström",

--- a/themes/Mausworks Night-color-theme.json
+++ b/themes/Mausworks Night-color-theme.json
@@ -353,6 +353,8 @@
       "scope": [
         "punctuation.definition.arguments.begin",
         "punctuation.definition.arguments.end",
+        "punctuation.bracket",
+        "punctuation.paren",
         "meta.block"
       ],
       "settings": {

--- a/themes/Mausworks Night-color-theme.json
+++ b/themes/Mausworks Night-color-theme.json
@@ -408,6 +408,18 @@
       }
     },
     {
+      "name": "Haskell arrow and infix operators",
+      "scope": [
+        "source.haskell keyword.operator.arrow",
+        "source.haskell keyword.operator.infix",
+        "source.haskell keyword.operator.double-colon",
+        "source.haskell keyword.operator.lambda"
+      ],
+      "settings": {
+        "foreground": "#5EE8D9"
+      }
+    },
+    {
       "name": "Function, Special Method",
       "scope": [
         "entity.name.function",
@@ -484,8 +496,7 @@
         "keyword.other.unit",
         "keyword.other",
         "keyword",
-        "storage.modifier",
-        "storage.type"
+        "storage.modifier"
       ],
       "settings": {
         "foreground": "#effffd58"
@@ -548,8 +559,13 @@
         "entity.other.inherited-class",
         "support.other.namespace.use.php",
         "support.other.namespace.php",
+        "entity.name.namespace",
         "markup.changed.git_gutter",
-        "support.type.sys-types"
+        "support.type.sys-types",
+        "meta.function.type-declaration",
+        "meta.declaration.data.algebraic",
+        "meta.declaration.type",
+        "storage.type.haskell"
       ],
       "settings": {
         "foreground": "#48F9BB"

--- a/themes/Mausworks Night-color-theme.json
+++ b/themes/Mausworks Night-color-theme.json
@@ -527,7 +527,6 @@
       "name": "Mutable storage modifier (in e.g Rust)",
       "scope": "storage.modifier.mut",
       "settings": {
-        "foreground": "#5EE8D9",
         "fontStyle": "italic"
       }
     },
@@ -574,6 +573,7 @@
         "support.other.namespace.use.php",
         "support.other.namespace.php",
         "entity.name.namespace",
+        "keyword.operator.namespace",
         "markup.changed.git_gutter",
         "support.type.sys-types",
         "meta.function.type-declaration",

--- a/themes/Mausworks Night-color-theme.json
+++ b/themes/Mausworks Night-color-theme.json
@@ -495,6 +495,7 @@
       "scope": [
         "keyword.other.unit",
         "keyword.other",
+        "keyword.operator.expression",
         "keyword",
         "storage.modifier"
       ],

--- a/themes/Mausworks Night-color-theme.json
+++ b/themes/Mausworks Night-color-theme.json
@@ -503,9 +503,22 @@
       }
     },
     {
-      "name": "Super and self variables",
-      "scope": ["variable.language.super", "variable.language.self"],
+      "name": "Storage keywords (let, var, const, etc ...)",
+      "scope": ["storage.type"],
       "settings": {
+        "foreground": "#effffd58"
+      }
+    },
+    {
+      "name": "super, self, base, this",
+      "scope": [
+        "variable.language.super",
+        "variable.language.self",
+        "variable.language.base",
+        "variable.language.this"
+      ],
+      "settings": {
+        "foreground": "#5EE8D9",
         "fontStyle": "italic"
       }
     },


### PR DESCRIPTION
This PR changes so that.

- All languages: Self, this, super and base are now cyan and italic
- Haskell: Most operators are now cyan (unlike other languages)
- Haskell: Type definitions are green (like other languages)
- Haskell: Parens and brackets are white (like other languages)
- Rust (and other languages): Namespaces are now green
- Rust: The mutable operator (mut) is now gray (but still italic)
- JavaScript & TypeScript: The `in` and `of` keywords are now gray

Closes #10 